### PR TITLE
Setup and installation instructions for R

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,41 @@
+## Installation
+See [this guide](https://github.com/exercism/xr/blob/master/docs/INSTALLATION.md) for instructions on how to setup your local R environment.
+
+## How the R files are organized and why
+When a new exercism problem is fetched, what you get is a folder with this structure:
+
+```
+./Bob
+├── Bob.Rproj
+├── DESCRIPTION
+├── NAMESPACE
+├── R
+│   └── bob.R
+└── tests
+    ├── testthat
+    │   └── test_bob.R
+    └── testthat.R
+```
+
+This is package skeleton created using `devtools::create`. Having a whole package to run tests for a single script adds a little bit of clutter and complexity, but it also provides some consistency and allows us to take advantage of tooling.
+
+The intent is to structure problems within self-contained modules or classes as is done for other languages at exercism. Unfortunately, R does not support this pattern, hence this workaround (see [this Stack Overflow question](https://stackoverflow.com/questions/15789036/namespaces-without-packages) for more explanation).
+
+## How to implement your solution in RStudio
+In the example file tree above, there is a file called `Bob.Rproj`, which is an RStudio project file. Open it in RStudio.
+
+In the `./Bob/R` folder, you will find a single script file (e.g. `bob.R`), which provides some skeleton code for you to implement your solution. Fill it in, and run the test suite (see next section).
+
+## How to run tests inside of RStudio
+If you opened the `RProj` file, the IDE will be configured to run the test suite for you. To run your tests, from the menu select `Build > Test Package` or use the keyboard shortcut `Cmd/Ctrl-Shift-T`. The test report should appear in one of the panels.
+
+You can view the specs in the `./Bob/tests/testthat` folder.
+
+## How to run tests on the command line
+If you prefer to not use an IDE for your coding and test running, you will need to create a helper script. At the root of the problem folder, create this one-line script `run_tests.R`:
+
+```
+devtools::test()
+```
+
+Then, on the command line, type `Rscript run_tests.R` to run the test suite.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,23 +1,27 @@
-If R isn't already available on your system download and install the latest binary for your platform from [the R project website](http://cran.r-project.org/).
+## Install the R runtime
+Visit the [CRAN homepage](https://cran.r-project.org/). There you will find download links for Linux, Mac OSX, and Windows. Download and run the installer for your operating system.
 
-## Packages
+If you are using Windows, you may also need to install the [Rtools](https://cran.r-project.org/bin/windows/Rtools/) suite, as some packages may depend on it. Mac users may need to install XCode (particularly its command-line tools) for the same reason.
 
-The [R Package Index](http://cran.r-project.org/web/packages/) contains thousands of packages.
-Pretty much each of them is installable by running `library("packagename")` from within your R code.
+## Install the RStudio IDE
+RStudio is a popular cross-platform integrated development environment (IDE) for programming in R (and also supports other languages like Python, JavaScript, and Markdown). Using RStudio will make writing your code solutions and running tests easier.
 
-## Downloading the Test Runner
+Download and install the [current stable version of RStudio](https://www.rstudio.com/products/rstudio/download/). Or, alternatively, get the [preview version](https://www.rstudio.com/products/rstudio/download/preview/) of an upcoming release.
 
-### Linux/Mac users
+## Install the R packages for running tests
+The test runner for the specs is the [`testthat`](https://github.com/hadley/testthat) library from Hadley Wickham, which is a popular choice for R library authors. We also download the [`devtools`](https://github.com/hadley/devtools) library, which is necessary for some parts of the workflow.
 
-Download the `run_tests` R script, save it to `/usr/local/bin`, and make it executable:
+To install these libraries, type the following in your RStudio console (or wherever you are using R).
 
-```bash
-$ curl https://raw.githubusercontent.com/morphatic/xr/master/bin/run_tests.R -o /usr/local/bin/run_tests
-$ chmod +x /usr/local/bin/run_tests
+
+```{R}
+install.packages("testthat")
+install.packages("devtools")
 ```
 
-### Windows users
+While it is unlikely that you will _need_ to install packages to solve the exercism problems, you may want to bring in a general-purpose utility packages like [`magrittr`](https://github.com/smbache/magrittr) that suit your programming style. To install and load a package like `magrittr`:
 
-1. Download [run_tests.R](https://raw.githubusercontent.com/morphatic/xr/master/bin/run_tests.R) and [run_tests.bat](https://raw.githubusercontent.com/morphatic/xr/master/bin/run_tests.bat)
-1. Save them to `C:\Program Files\R\R-X.X.X\bin` where `X.X.X` refers the version of R you have
-1. Make sure that `C:\Program Files\R\R-X.X.X\bin` has been added to your `PATH` variable. (If you don't know what [a `PATH` variable](http://en.wikipedia.org/wiki/PATH_%28variable%29) is, here's [an easy-to-use `PATH` editor](https://patheditor2.codeplex.com/). You can add the R directory in either the User or System `PATH`.)
+```{R}
+install.packages("magrittr")
+library(magrittr)
+```


### PR DESCRIPTION
Relates to #3. I'll squash and rebase this when I'm done.

I'd like to pick up the torch from the earlier contributor. These (WIP) setup instructions describe a pretty mainstream path to setting up an R environment based around RStudio. I think this is a good way to go, as there is a lot of documentation and e-learning resources based around this IDE. 

One kind of significant departure from the original PR is that I'd like to use the `testthat` test runner instead of `runit`, as this seems to be more popular for R library writers and has some good docs and RStudio support.

I plan on writing some instructions on running tests through the command-line too.